### PR TITLE
Adding automated build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,27 +10,23 @@ jobs:
   build:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
-      
-      - uses: ruby/setup-ruby@v1
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
 
-      - uses: reitzig/actions-asciidoctor@v2.0.0
+      - name: Setup Asciidoctor
+        uses: reitzig/actions-asciidoctor@v2.0.0
 
-      - run: mkdir target
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - run: asciidoctor --source-dir=. --destination-dir=target  --trace --base-dir=. '*/*.adoc' > target/build.log
+      - name: Build
+        run: asciidoctor --source-dir=. --destination-dir=./target  --trace --base-dir=. '*/*.adoc'
 
-      - uses: actions/upload-artifact@v2
+      - name: Store Result
+        uses: actions/upload-artifact@v2
         with:
-          name: build-log
-          path: target/build.log
-          if-no-files-found: ignore
-
-      - uses: actions/upload-artifact@v2
-        with:
-          name: build-result
+          name: result
           path: target
           if-no-files-found: error
-        

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+
+      - uses: reitzig/actions-asciidoctor@v2.0.0
+
+      - run: mkdir target
+
+      - run: asciidoctor --source-dir=. --destination-dir=target  --trace --base-dir=. '*/*.adoc' > target/build.log
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-log
+          path: target/build.log
+          if-no-files-found: ignore
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build-result
+          path: target
+          if-no-files-found: error
+        


### PR DESCRIPTION
I'd like to prevent "It builds on my machine" and simlar situations ;-)
Automated builds are always a good way to prevent them.

### When does the Action executes?
The build runs everytime:
* anyone pushes to branch main
* on every pull request

### What does the Action does?
The build basicly:
1. Setup an Ubuntu with Asciidoctor installed
2. Checkout sources from the current branch/pr
3. Build with ascidoctor
4. Provide HTML-result as artifact

### Example
Example PR wihtin [my fork](https://github.com/MBoegers/website-adoptium-documentation/pull/2)